### PR TITLE
fix(release): commit Rust version metadata before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -342,6 +342,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Checkout requested Rust tag
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          set -euo pipefail
+          tag="${{ github.event.inputs.rust_only }}"
+          tag="${tag#refs/tags/}"
+          case "$tag" in
+            kanbus-rust-*) ;;
+            v*) tag="kanbus-rust-${tag#v}" ;;
+            *) tag="kanbus-rust-${tag}" ;;
+          esac
+          git fetch --tags origin "refs/tags/${tag}:refs/tags/${tag}"
+          git checkout --detach "${tag}"
+
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -385,7 +399,7 @@ jobs:
             rust/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.lock') }}
 
-      - name: Sync crate version to release tag
+      - name: Verify crate version matches release tag
         working-directory: rust
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
@@ -393,38 +407,25 @@ jobs:
           else
             tag_version="${{ github.ref_name }}"
           fi
+          tag_version="${tag_version#refs/tags/}"
           tag_version="${tag_version#kanbus-rust-}"
           tag_version="${tag_version#v}"
           if [ -z "$tag_version" ]; then
             echo "Release tag did not include a crate version" >&2
             exit 1
           fi
-          python - <<'PY' "$tag_version"
-          import pathlib, re, sys
+          manifest_version="$(python - <<'PY'
+          import tomllib
 
-          desired = sys.argv[1]
-          path = pathlib.Path("Cargo.toml")
-          text = path.read_text()
-
-          pattern = r'(?m)^version\s*=\s*"([^"]*)"'
-          match = re.search(pattern, text)
-          if not match:
-              print("version field not found; check Cargo.toml format")
-              sys.exit(1)
-
-          current = match.group(1)
-          if current == desired:
-              print(f"version already {current}; nothing to do")
-              sys.exit(0)
-
-          new_text = re.sub(pattern, f'version = \"{desired}\"', text, count=1)
-          path.write_text(new_text)
-          print(f"version updated {current} -> {desired}")
+          with open("Cargo.toml", "rb") as handle:
+              print(tomllib.load(handle)["package"]["version"])
           PY
-
-      - name: Update Cargo.lock
-        working-directory: rust
-        run: cargo generate-lockfile
+          )"
+          if [ "$manifest_version" != "$tag_version" ]; then
+            echo "Cargo.toml version ${manifest_version} does not match release tag version ${tag_version}" >&2
+            exit 1
+          fi
+          echo "Cargo.toml version matches release tag: ${tag_version}"
 
       - name: fmt
         working-directory: rust
@@ -450,6 +451,7 @@ jobs:
           else
             version="${{ github.ref_name }}"
           fi
+          version="${version#refs/tags/}"
           version="${version#kanbus-rust-}"
           version="${version#v}"
           python - <<'PY' "$version"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -76,12 +76,14 @@ CI runs this suite in the `beads-interop` job after the standard quality gates.
 
 ## CI publish (semantic-release + crates.io)
 
-Semantic-release runs in `python/` and creates version tags. The release workflow then:
-1. Builds and uploads Python to PyPI (semantic-release).
-2. Syncs `rust/Cargo.toml` version to the semantic-release tag.
-3. Publishes the Rust crate from `rust/`.
+Semantic-release runs in `python/` and creates the release commit. That commit
+updates the Python package version, `rust/Cargo.toml`, and `rust/Cargo.lock`
+before creating the `kanbus-py-*` tag. The semantic-release workflow then adds a
+companion `kanbus-rust-*` tag at the same commit, and `release.yml` publishes
+from that tagged source tree.
 
 Rust publish guardrails:
+- The crate version in `rust/Cargo.toml` must match the `kanbus-rust-*` tag.
 - Steps: `cargo fmt --check`, `cargo clippy --locked -- -D warnings`, `cargo test --locked`, `cargo package --locked`, `cargo publish --locked`.
 - Requires repository secret `CARGO_REGISTRY_TOKEN`.
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -62,10 +62,14 @@ line-length = 88
 target-version = "py311"
 
 [tool.semantic_release]
-version_toml = ["pyproject.toml:project.version"]
-version_variable = ["src/kanbus/__init__.py:__version__"]
+version_toml = [
+    "pyproject.toml:project.version",
+    "../rust/Cargo.toml:package.version",
+]
+version_variables = ["src/kanbus/__init__.py:__version__"]
 tag_format = "kanbus-py-{version}"
 changelog_file = "CHANGELOG.md"
-build_command = "python -m build"
+assets = ["rust/Cargo.lock"]
+build_command = "cargo update --manifest-path ../rust/Cargo.toml -p kanbus --precise $NEW_VERSION && python -m build"
 allow_zero_version = true
 major_on_zero = false

--- a/python/src/kanbus/__init__.py
+++ b/python/src/kanbus/__init__.py
@@ -6,4 +6,4 @@ Kanbus Python package.
 This patch is a no-op change to trigger a release build.
 """
 
-__version__ = "0.17.0"
+__version__ = "0.18.2"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1216,7 +1216,7 @@ dependencies = [
 
 [[package]]
 name = "kanbus"
-version = "0.18.0"
+version = "0.18.2"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kanbus"
-version = "0.18.0"
+version = "0.18.2"
 edition = "2021"
 description = "High-performance CLI and web console for the Kanbus issue tracker. Includes kanbus (CLI) and kanbus-console (web UI server)."
 license = "MIT"

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -454,9 +454,7 @@ fn merge_issue_views(mut beads: IssueData, project: IssueData) -> IssueData {
             beads.comments.push(comment);
         }
     }
-    beads
-        .comments
-        .sort_by(|a, b| a.created_at.cmp(&b.created_at));
+    beads.comments.sort_by_key(|comment| comment.created_at);
 
     // Fill in empty descriptive fields from the project copy when beads lacks them.
     if beads.description.is_empty() && !project.description.is_empty() {

--- a/rust/src/policy_loader.rs
+++ b/rust/src/policy_loader.rs
@@ -87,7 +87,7 @@ mod tests {
         fs::write(temp.path().join("notes.txt"), "not a policy").expect("write txt");
 
         let mut loaded = load_policies(temp.path()).expect("load policies");
-        loaded.sort_by(|a, b| a.0.cmp(&b.0));
+        loaded.sort_by_key(|policy| policy.0.clone());
         assert_eq!(loaded.len(), 1);
         assert_eq!(loaded[0].0, "valid.policy");
     }


### PR DESCRIPTION
**Summary**
- Move Rust crate version stamping into semantic-release so the release commit updates Python metadata, rust/Cargo.toml, and rust/Cargo.lock before tagging.
- Replace release-time Rust metadata mutation with a tag/version validation step in .github/workflows/release.yml.
- Restore clean cargo package/publish commands without --allow-dirty and document the updated release model.
- Align current committed Python and Rust package versions to 0.18.2.

**Why**
- Published crates should match the tagged source tree exactly.
- This avoids dirty checkout packaging and prevents future version drift between Python and Rust release metadata.

**Validation**
- git diff --check
- Parsed python/pyproject.toml with Python tomllib.
- Parsed .github/workflows/release.yml with Python YAML tooling.
- bash -n for the changed workflow shell blocks.
- cargo metadata --locked --no-deps --format-version 1 reports kanbus 0.18.2.
- cargo package --locked --list --allow-dirty confirmed Cargo.toml, Cargo.lock, and embedded console assets are included.
- semantic-release --noop version --no-push --no-vcs-release --skip-build ran and reported no release because the local branch is develop, not a configured release branch.

**Expected Outcome**
- Future kanbus-rust-* releases publish from clean tagged source where rust/Cargo.toml and rust/Cargo.lock already match the release version.
- Manual Rust release dispatches validate the requested tag instead of modifying the checkout.

**Kanbus / Task Tracking**
- N/A